### PR TITLE
update for supporting vertical coordinate with adaptive density classes

### DIFF
--- a/packages/BLOM_DIAG/blom_diag_template.sh
+++ b/packages/BLOM_DIAG/blom_diag_template.sh
@@ -443,6 +443,10 @@ do
             $DIAG_CODE/check_history_vars.sh $CASENAME $FIRST_YR_CLIMO $LAST_YR_CLIMO $PATHDAT climo_ann
             echo $required_vars_climo_mon > $WKDIR/attributes/required_vars
             $DIAG_CODE/check_history_vars.sh $CASENAME $FIRST_YR_CLIMO $LAST_YR_CLIMO $PATHDAT climo_mon
+            # Determine grid type from an individual file
+            if [ ! -f $WKDIR/attributes/grid_${CASENAME} ] && [ -z $PGRIDPATH ]; then
+                $DIAG_CODE/determine_grid_type.sh $CASENAME
+            fi
             if [ -f $WKDIR/attributes/vars_climo_ann_${CASENAME}_hy ]; then
                 $DIAG_CODE/compute_climo.sh hy $CASENAME $FIRST_YR_CLIMO $LAST_YR_CLIMO $PATHDAT $CLIMO_TS_DIR
             fi

--- a/packages/BLOM_DIAG/code/check_history_vars.sh
+++ b/packages/BLOM_DIAG/code/check_history_vars.sh
@@ -67,6 +67,12 @@ if [ ! -f $WKDIR/attributes/sst_file_${casename} ]; then
     exit 1
 fi
 
+# Get grid information
+if [ ! -f $WKDIR/attributes/grid_${casename} ] && [ -z $PGRIDPATH ]; then
+    $DIAG_CODE/determine_grid_type.sh $casename
+fi
+zlevel=$(awk 'NR==4' $WKDIR/attributes/grid_${casename}|cut -d':' -f2)
+
 for filetype in $filetypes
 do
     check_vars=1
@@ -114,7 +120,7 @@ do
         var_list_remaining=" "
         for var in $req_vars
         do
-            $NCKS --quiet -d y,0 -d x,0 -d sigma,0 -d depth,0 -v $var $fullpath_filename >/dev/null 2>&1
+            $NCKS --quiet -d y,0 -d x,0 -d ${zlevel},0 -d depth,0 -v $var $fullpath_filename >/dev/null 2>&1
             if [ $? -eq 0 ]; then
                 find_any=1
                 if [ $first_find -eq 1 ]; then

--- a/packages/BLOM_DIAG/code/compute_climo.sh
+++ b/packages/BLOM_DIAG/code/compute_climo.sh
@@ -49,10 +49,8 @@ do
 done
 [ -z $filetag ] && echo "** NO ocean data found, EXIT ... **" && exit 1
 
-if [ ! -f $WKDIR/attributes/grid_${casename} ] && [ -z $PGRIDPATH ]; then
-    $DIAG_CODE/determine_grid_type.sh $casename
-fi
 gp=$(awk 'NR==2' $WKDIR/attributes/grid_${casename} |cut -d':' -f2)
+zlevel=$(awk 'NR==4' $WKDIR/attributes/grid_${casename}|cut -d':' -f2)
 
 # COMPUTE CLIMATOLOGY FROM ANNUAL FILES
 if [ $filetype == hy ]; then
@@ -77,7 +75,7 @@ if [ $filetype == hy ]; then
                 eval $NCRA -h -O --no_tmp_fl --hdr_pad=10000 -v $var -p $pathdat ${filenames[*]} $climodir/var_tmp.nc &
                 wait $!
                 $NCATTED -h -a eulaVlliF_,depth,d,, -a eulaVlliF_,lat,d,, \
-                         -a eulaVlliF_,sigma,d,, -a eulaVlliF_,$var,d,, \
+                         -a eulaVlliF_,${zlevel},d,, -a eulaVlliF_,$var,d,, \
                          $climodir/var_tmp.nc
                 $NCKS -h -A -v $var $climodir/var_tmp.nc $ann_avg_file
                 wait $!

--- a/packages/BLOM_DIAG/code/determine_grid_type.sh
+++ b/packages/BLOM_DIAG/code/determine_grid_type.sh
@@ -148,3 +148,8 @@ else
  if [ -f $WKDIR/sst_tmp.nc ]; then
      rm -f $WKDIR/sst_tmp.nc
  fi
+
+# Determine if layer dimension is 'sigma2' with time-invariant density or 'layer' with evolving density classes
+$NCKS --cdl -m ${fullpath_filename} | cut -d ':' -f 1 | cut -d '=' -s -f 1 | grep  'layer' >/dev/null 2>&1 \
+  && zlevel='layer' || zlevel='sigma'
+echo "zlevel:$zlevel" >> $WKDIR/attributes/grid_${casename}


### PR DESCRIPTION
Support both vertical coordinates in  BLOM of time-invariant densities as `sigma` and time-adaptive densities as `layer`, in accordance to https://github.com/NorESMhub/BLOM/pull/673

An example with these modifications:
https://ns2345k.web.sigma2.no/datalake/diagnostics/noresm/yanchun/NOIIAJRARYF8485OC_TL319_tn14_moddia_20251003/BLOM_DIAG/

