### PR TITLE
update mixed layer depth diagnostics

### DIFF
--- a/packages/BLOM_DIAG/blom_diag_template.sh
+++ b/packages/BLOM_DIAG/blom_diag_template.sh
@@ -288,9 +288,12 @@ if [ $CNTL == USER ]; then
 fi
 
 # Set required variables for climatology and time series
-required_vars_climo="sealv,templvl,salnlvl,mmflxd,temp,saln,dz,sst,sss,mlts,mhflx,msflx"
-required_vars_climo_ann="sealv,templvl,salnlvl,mmflxd,mhflx,msflx,mlts"
-required_vars_climo_mon="temp,saln,dz,sst,sss,mlts"
+required_vars_climo="sealv,templvl,salnlvl,mmflxd,temp,saln,dz,sst,sss,mhflx,msflx"
+required_vars_climo+=",mld,bld,mlts,mldl82,mldb04"
+required_vars_climo_ann="sealv,templvl,salnlvl,mmflxd,mhflx,msflx"
+required_vars_climo_ann+=",mld,bld,mlts,mldl82,mldb04"
+required_vars_climo_mon="temp,saln,dz,sst,sss"
+required_vars_climo_mon+=",mld,bld,mlts,mldl82,mldb04"
 required_vars_ts_ann="mmflxd,voltr,temp,saln,templvl,salnlvl,dp,sst,sss,tempga,salnga,sstga,sssga"
 
 # Check which sets should be plotted based on CLIMO_TIME_SERIES_SWITCH
@@ -917,11 +920,11 @@ if [ $set_3 -eq 1 ]; then
 
     # Compute and plot monthly MLD if 'mlts' is not presented on model output
     TEST_FILE=$CLIMO_TS_DIR1/${CASENAME1}_01_${FYR_PRNT_CLIMO1}-${LYR_PRNT_CLIMO1}_climo_remap.nc
-    $NCKS --quiet -d lon,0 -d lat,0 -d time,0 -v mlts $TEST_FILE >/dev/null 2>&1
-    IFMLTS=$?
-    $NCKS --quiet -d lon,0 -d lat,0 -d sigma,0 -v temp,saln,dz $TEST_FILE >/dev/null 2>&1
+    $NCKS --quiet -d lon,0 -d lat,0 -d time,0 -v mldb04 $TEST_FILE >/dev/null 2>&1
+    IFMLDB04=$?
+    $NCKS --quiet -d lon,0 -d lat,0 -v temp,saln,dz $TEST_FILE >/dev/null 2>&1
     IFTS=$?
-    if [ "$IFMLTS" != 0 ] && [ "$IFTS" == 0 ]; then
+    if [ "$IFMLDB04" != 0 ] && [ "$IFTS" == 0 ]; then
         echo "2D monthly MLD plots (plot_mld_monthly.ncl)..."
         MLD_CLIM_DIR1=$CLIMO_TS_DIR1/MLD
         if [ -d $MLD_CLIM_DIR1 ]; then
@@ -941,10 +944,10 @@ if [ $set_3 -eq 1 ]; then
             export INFILE1=$CLIMO_TS_DIR1/${CASENAME1}_${month}_${FYR_PRNT_CLIMO1}-${LYR_PRNT_CLIMO1}_climo_remap.nc
             export INFILE2=$DIAG_OBS/MLD/mld_clim_WOCE_${month}.nc
             export CMONTH=$month
-            export NCOUTPATH1=$MLD_CLIM_DIR1/mld_${FYR_PRNT_CLIMO1}-${LYR_PRNT_CLIMO1}_${month}.nc
+            export NCOUTPATH1=$MLD_CLIM_DIR1/mldb04_${FYR_PRNT_CLIMO1}-${LYR_PRNT_CLIMO1}_${month}.nc
             if [ $CNTL == USER ]; then
                 export INFILE2=$CLIMO_TS_DIR2/${CASENAME2}_${month}_${FYR_PRNT_CLIMO2}-${LYR_PRNT_CLIMO2}_climo_remap.nc
-                export NCOUTPATH2=$MLD_CLIM_DIR2/mld_${FYR_PRNT_CLIMO2}-${LYR_PRNT_CLIMO2}_${month}.nc
+                export NCOUTPATH2=$MLD_CLIM_DIR2/mldb04_${FYR_PRNT_CLIMO2}-${LYR_PRNT_CLIMO2}_${month}.nc
             fi
             eval $NCL -Q < $DIAG_CODE/plot_mld_monthly.ncl &
             pid+=($!)
@@ -964,31 +967,31 @@ if [ $set_3 -eq 1 ]; then
         mld_files2=()
         for month in 01 02 03 04 05 06 07 08 09 10 11 12
         do
-            mld_file1=mld_${FYR_PRNT_CLIMO1}-${LYR_PRNT_CLIMO1}_${month}.nc
+            mld_file1=mldb04_${FYR_PRNT_CLIMO1}-${LYR_PRNT_CLIMO1}_${month}.nc
             if [ -f $MLD_CLIM_DIR1/$mld_file1 ]; then
                 mld_files1+=($mld_file1)
             else
-                echo "ERROR: cannot find $MLD_CLIM_DIR1/mld_${FYR_PRNT_CLIMO1}-${LYR_PRNT_CLIMO1}_${month}.nc"
+                echo "ERROR: cannot find $MLD_CLIM_DIR1/mldb04_${FYR_PRNT_CLIMO1}-${LYR_PRNT_CLIMO1}_${month}.nc"
                 #echo "*** EXITING THE SCRIPT ***"
                 #exit 1
             fi
             if [ $CNTL == USER ]; then
-                mld_file2=mld_${FYR_PRNT_CLIMO2}-${LYR_PRNT_CLIMO2}_${month}.nc
+                mld_file2=mldb04_${FYR_PRNT_CLIMO2}-${LYR_PRNT_CLIMO2}_${month}.nc
                 if [ -f $MLD_CLIM_DIR2/$mld_file2 ]; then
                     mld_files2+=($mld_file2)
                 else
-                    echo "ERROR: cannot find $MLD_CLIM_DIR2/mld_${FYR_PRNT_CLIMO2}-${LYR_PRNT_CLIMO2}_${month}.nc"
+                    echo "ERROR: cannot find $MLD_CLIM_DIR2/mldb04_${FYR_PRNT_CLIMO2}-${LYR_PRNT_CLIMO2}_${month}.nc"
                     #echo "*** EXITING THE SCRIPT ***"
                     #exit 1
                 fi
             fi
         done
         # Calculate annual mean MLD
-        mld_ann_file1=$MLD_CLIM_DIR1/mld_${FYR_PRNT_CLIMO1}-${LYR_PRNT_CLIMO1}_ANN.nc
-        $NCRA -O -w 31,28,31,30,31,30,31,31,30,31,30,31 --no_tmp_fl --hdr_pad=10000 -v mld -p $MLD_CLIM_DIR1 ${mld_files1[*]} $mld_ann_file1
+        mld_ann_file1=$MLD_CLIM_DIR1/mldb04_${FYR_PRNT_CLIMO1}-${LYR_PRNT_CLIMO1}_ANN.nc
+        $NCRA -O -w 31,28,31,30,31,30,31,31,30,31,30,31 --no_tmp_fl --hdr_pad=10000 -v mldb04 -p $MLD_CLIM_DIR1 ${mld_files1[*]} $mld_ann_file1
         if [ $CNTL == USER ]; then
-            mld_ann_file2=$MLD_CLIM_DIR2/mld_${FYR_PRNT_CLIMO2}-${LYR_PRNT_CLIMO2}_ANN.nc
-            $NCRA -O -w 31,28,31,30,31,30,31,31,30,31,30,31 --no_tmp_fl --hdr_pad=10000 -v mld -p $MLD_CLIM_DIR2 ${mld_files2[*]} $mld_ann_file2
+            mld_ann_file2=$MLD_CLIM_DIR2/mldb04_${FYR_PRNT_CLIMO2}-${LYR_PRNT_CLIMO2}_ANN.nc
+            $NCRA -O -w 31,28,31,30,31,30,31,31,30,31,30,31 --no_tmp_fl --hdr_pad=10000 -v mldb04 -p $MLD_CLIM_DIR2 ${mld_files2[*]} $mld_ann_file2
         fi
         echo "2D annual-mean MLD plot (plot_mld_annual.ncl)..."
         export INFILE1=$mld_ann_file1
@@ -1015,12 +1018,12 @@ if [ $set_3 -eq 1 ]; then
     echo "Generating html for set3 plots"
     echo "-----------------------"
     echo " "
-    if ls $WEBDIR/set3/set3_*_mlts_${cinfo}.png >/dev/null 2>&1
-    then
-        cat $DIAG_HTML/webpage3.html | sed "s/_mld_CINFO/_mlts_CINFO/g" | sed "s/MLD <br> (TS-derived)/MLTS <br> (online-diagnosed)/g" \
-                                     | sed "s/CINFO.png/${cinfo}.png/g" >> $WEBDIR/index.html
-    else
-        cat $DIAG_HTML/webpage3.html | sed "s/CINFO.png/${cinfo}.png/g" >> $WEBDIR/index.html
+    cat $DIAG_HTML/webpage3.html | sed "s/CINFO.png/${cinfo}.png/g" >> $WEBDIR/index.html
+    if $(ls $WEBDIR/set3/set3_*_bld_${cinfo}.png >/dev/null 2>&1); then
+        sed -i "s/_mld_${cinfo}/_bld_${cinfo}/g" $WEBDIR/index.html
+    fi
+    if $(ls $WEBDIR/set3/set3_*_mldl82_${cinfo}.png >/dev/null 2>&1); then
+        sed -i "s/_mlts_${cinfo}/_mldl82_${cinfo}/g" $WEBDIR/index.html
     fi
 
 fi

--- a/packages/BLOM_DIAG/blom_diag_template.sh
+++ b/packages/BLOM_DIAG/blom_diag_template.sh
@@ -294,7 +294,7 @@ required_vars_climo_ann="sealv,templvl,salnlvl,mmflxd,mhflx,msflx"
 required_vars_climo_ann+=",mld,bld,mlts,mldl82,mldb04"
 required_vars_climo_mon="temp,saln,dz,sst,sss"
 required_vars_climo_mon+=",mld,bld,mlts,mldl82,mldb04"
-required_vars_ts_ann="mmflxd,voltr,temp,saln,templvl,salnlvl,dp,sst,sss,tempga,salnga,sstga,sssga"
+required_vars_ts_ann="mmflxd,voltr,masstr,temp,saln,templvl,salnlvl,dp,sst,sss,tempga,salnga,sstga,sssga"
 
 # Check which sets should be plotted based on CLIMO_TIME_SERIES_SWITCH
 if [ $CLIMO_TIME_SERIES_SWITCH == ONLY_CLIMO ]; then

--- a/packages/BLOM_DIAG/code/compute_ann_time_series.sh
+++ b/packages/BLOM_DIAG/code/compute_ann_time_series.sh
@@ -50,7 +50,7 @@ done
 first_yr_prnt=$(printf "%04d" ${first_yr})
 last_yr_prnt=$(printf "%04d" ${last_yr})
 ann_ts_file=${casename}_ANN_${first_yr_prnt}-${last_yr_prnt}_ts_${filetype}.nc
-ann_ts_var_list="mmflxd voltr temp saln templvl salnlvl sst sss tempga salnga sstga sssga"
+ann_ts_var_list="mmflxd voltr masstr temp saln templvl salnlvl sst sss tempga salnga sstga sssga"
 
 # Determine file tag
 for ocn in blom micom
@@ -340,7 +340,7 @@ do
             done
         fi
         # Section transports
-        if [ $var == voltr ]; then
+        if [ $var == voltr ] || [ $var == masstr ]; then
             echo "Section transports (yrs ${YR_start}-${YR_end})"
             iproc=1
             while [ $iproc -le $nyrs ]
@@ -350,7 +350,7 @@ do
                 infile=${casename}_ANN_${yr_prnt}.nc
                 outfile=${var}_${casename}_ANN_${filetype}_${yr_prnt}.nc
                 if [ ! -f $tsdir/ann_ts/$outfile ]; then
-                    $NCKS --no_tmp_fl -O -v voltr,section $WKDIR/$infile $WKDIR/$outfile
+                    $NCKS --no_tmp_fl -O -v ${var},section $WKDIR/$infile $WKDIR/$outfile
                 fi
                 let iproc++
             done

--- a/packages/BLOM_DIAG/code/functions_latlon.ncl
+++ b/packages/BLOM_DIAG/code/functions_latlon.ncl
@@ -23,7 +23,7 @@ begin
       xvar@units = "degC"
       assignFillValue(xvar,xvar)
    else
-      print("get_templvl: no templvl variable present")
+;      print("get_templvl: no templvl variable present")
       xvar = -999.0
    end if
    return (xvar)
@@ -45,13 +45,13 @@ begin
       xvar@units = "g/kg"
       assignFillValue(xvar,xvar)
    else
-      print("get_salnlvl: no salnlvl variable present")
+;      print("get_salnlvl: no salnlvl variable present")
       xvar = -999.0
    end if
    return (xvar)
 end
 
-function get_mld (inptr:file)
+function cal_mldb04 (inptr:file)
 ;--------------------------------------------------------
 ; Compute mld by density changes in the uppermost layers
 ; (de Boyer Montegut et al. 2004)
@@ -162,7 +162,7 @@ begin
       delete(nlat)
       delete(nz)
    else
-      print("get_mld: no temp and/or saln and/or dz present: cannot compute mld.")
+      print("cal_mldb04: no temp and/or saln and/or dz present: cannot compute mld.")
       xvar = -999.0
    end if
    return (xvar)
@@ -182,7 +182,7 @@ begin
       xvar@units = "m"
       assignFillValue(xvar,xvar)
    else
-      print("get_sealv: no sealv variable present")
+;      print("get_sealv: no sealv variable present")
       xvar = -999.0
    end if
    return (xvar)
@@ -201,7 +201,7 @@ begin
       xvar@units = "degC"
       assignFillValue(xvar,xvar)
    else
-      print("get_sst: no sst variable present")
+;      print("get_sst: no sst variable present")
       xvar = -999.0
    end if
    return (xvar)
@@ -220,7 +220,47 @@ begin
       xvar@units = "g/kg"
       assignFillValue(xvar,xvar)
    else
-      print("get_sss: no sss variable present")
+;      print("get_sss: no sss variable present")
+      xvar = -999.0
+   end if
+   return (xvar)
+end
+
+function get_mld (inptr:file)
+begin
+   if (isfilevar(inptr,"mld" )) then
+     tmp = inptr->mld
+     if (typeof(tmp).eq."double") then
+        xvar = dble2flt(tmp(0,:,:))
+     else
+        xvar = tmp(0,:,:)
+     end if
+     xvar@long_name = "Mixed layer depth (mld)"
+     xvar@units = "m"
+     assignFillValue(xvar,xvar)
+     print(xvar@long_name)
+   else
+;      print("get_mld: no 'mld' variable present")
+      xvar = -999.0
+   end if
+   return (xvar)
+end
+
+function get_bld (inptr:file)
+begin
+   if (isfilevar(inptr,"bld" )) then
+     tmp = inptr->bld
+     if (typeof(tmp).eq."double") then
+        xvar = dble2flt(tmp(0,:,:))
+     else
+        xvar = tmp(0,:,:)
+     end if
+     xvar@long_name = "Mixed layer depth (bld)"
+     xvar@units = "m"
+     assignFillValue(xvar,xvar)
+     print(xvar@long_name)
+   else
+;      print("get_bld: no 'bld' variable present")
       xvar = -999.0
    end if
    return (xvar)
@@ -235,11 +275,52 @@ begin
       else
          xvar = tmp(0,:,:)
       end if
-      xvar@long_name = "Mixed layer depth"
+      xvar@long_name = "Mixed layer depth (mlts)"
       xvar@units = "m"
       assignFillValue(xvar,xvar)
+      print(xvar@long_name)
    else
-      print("get_mlts: no mlts variable present")
+;      print("get_mlts: no mlts variable present")
+      xvar = -999.0
+   end if
+   return (xvar)
+end
+
+function get_mldl82 (inptr:file)
+begin
+   if (isfilevar(inptr,"mldl82")) then
+      tmp = inptr->mldl82
+      if (typeof(tmp).eq."double") then
+         xvar = dble2flt(tmp(0,:,:))
+      else
+         xvar = tmp(0,:,:)
+      end if
+      xvar@long_name = "Mixed layer depth (mldl82)"
+      xvar@units = "m"
+      assignFillValue(xvar,xvar)
+      print(xvar@long_name)
+   else
+;      print("get_mldl82: no 'mldl82' variable present")
+      xvar = -999.0
+   end if
+   return (xvar)
+end
+
+function get_mldb04 (inptr:file)
+begin
+   if (isfilevar(inptr,"mldb04")) then
+      tmp = inptr->mldb04
+      if (typeof(tmp).eq."double") then
+         xvar = dble2flt(tmp(0,:,:))
+      else
+         xvar = tmp(0,:,:)
+      end if
+      xvar@long_name = "Mixed layer depth (mldb04)"
+      xvar@units = "m"
+      assignFillValue(xvar,xvar)
+      print(xvar@long_name)
+   else
+;      print("get_mldb04: no mldb04 variable present")
       xvar = -999.0
    end if
    return (xvar)

--- a/packages/BLOM_DIAG/code/functions_time_series.ncl
+++ b/packages/BLOM_DIAG/code/functions_time_series.ncl
@@ -8,8 +8,13 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 
 function get_voltr (inptr:file) 
 begin
-   if (isfilevar(inptr,"voltr")) then
-      tmp = inptr->voltr
+   if (isfilevar(inptr,"voltr") .or. isfilevar(inptr,"masstr")) then
+      if (isfilevar(inptr,"voltr")) then
+        tmp = inptr->voltr
+      else
+        tmp = inptr->masstr
+      end if
+
       if (typeof(tmp).eq."double") then
          xvar = dble2flt(tmp)
       else

--- a/packages/BLOM_DIAG/code/plot_latlon_annual.ncl
+++ b/packages/BLOM_DIAG/code/plot_latlon_annual.ncl
@@ -137,18 +137,21 @@ dcntrs_sealv=(/-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0.1,0.2,0.3,0.4,0.5,
 vars = (/"templvl0","templvl50","templvl100","templvl250","templvl500",\
          "templvl1000","templvl2000","templvl3000","templvl4000",\
          "salnlvl0","salnlvl50","salnlvl100","salnlvl250","salnlvl500",\
-         "salnlvl1000","salnlvl2000","salnlvl3000","salnlvl4000","mlts","sealv"/)
+         "salnlvl1000","salnlvl2000","salnlvl3000","salnlvl4000","sealv",\
+         "mld","bld","mlts","mldl82","mldb04"/)
 
 ; define contour intervals
 cntrs = (/cntrs_dummy,cntrs_dummy,cntrs_dummy,cntrs_dummy,cntrs_dummy,\
           cntrs_dummy,cntrs_templvl_bot,cntrs_templvl_bot,cntrs_templvl_bot,\
           cntrs_salnlvl_top,cntrs_salnlvl_top,cntrs_salnlvl_top,cntrs_salnlvl_top,cntrs_salnlvl_top,\
-          cntrs_salnlvl_bot,cntrs_salnlvl_bot,cntrs_salnlvl_bot,cntrs_salnlvl_bot,cntrs_mlts,cntrs_sealv/)
+          cntrs_salnlvl_bot,cntrs_salnlvl_bot,cntrs_salnlvl_bot,cntrs_salnlvl_bot,cntrs_sealv,\
+          cntrs_mlts,cntrs_mlts,cntrs_mlts,cntrs_mlts,cntrs_mlts/)
 
 dcntrs = (/dcntrs_templvl_top,dcntrs_templvl_top,dcntrs_templvl_top,dcntrs_templvl_top,dcntrs_templvl_top,\
            dcntrs_templvl_top,dcntrs_templvl_bot,dcntrs_templvl_bot,dcntrs_templvl_bot,\
            dcntrs_salnlvl_top,dcntrs_salnlvl_top,dcntrs_salnlvl_top,dcntrs_salnlvl_top,dcntrs_salnlvl_top,\
-           dcntrs_salnlvl_bot,dcntrs_salnlvl_bot,dcntrs_salnlvl_bot,dcntrs_salnlvl_bot,dcntrs_mlts,dcntrs_sealv/)
+           dcntrs_salnlvl_bot,dcntrs_salnlvl_bot,dcntrs_salnlvl_bot,dcntrs_salnlvl_bot,dcntrs_sealv,\
+           dcntrs_mlts,dcntrs_mlts,dcntrs_mlts,dcntrs_mlts,dcntrs_mlts/)
 
 nvars = dimsizes(vars)
 
@@ -165,7 +168,8 @@ if (compare .eq. "OBS") then
   obsvars = (/"t_an0","t_an50","t_an100","t_an250","t_an500",\
               "t_an1000","t_an2000","t_an3000","t_an4000",\
               "s_an0","s_an50","s_an100","s_an250","s_an500",\
-              "s_an1000","s_an2000","s_an3000","s_an4000","mld","mdot"/) 
+              "s_an1000","s_an2000","s_an3000","s_an4000","mdot",\
+              "mld","mld","mld","mld","mld"/) 
 end if
 ;-------------------------------------------------------------
 ; common resources for global contour plots 
@@ -213,14 +217,30 @@ pan@gsnPanelYWhiteSpacePercent = 2
 ;--------------------------------------------------------------
 
 do i = 0, nvars-1
-  ;print("==================")
-  ;print("====="+ vars(i))
+;  print("==================")
+;  print("====="+ vars(i))
 ;----------------------------
 ; Test case: CASE 1 MODEL
 ;----------------------------
 
+  if (vars(i) .eq. "mld") then
+    A = get_mld (inptr1)
+  end if
+
+  if (vars(i) .eq. "bld") then
+    A = get_bld (inptr1)
+  end if
+
   if (vars(i) .eq. "mlts") then
     A = get_mlts (inptr1)
+  end if
+
+  if (vars(i) .eq. "mldl82") then
+    A = get_mldl82 (inptr1)
+  end if
+
+  if (vars(i) .eq. "mldb04") then
+    A = get_mldb04 (inptr1)
   end if
 
   if (vars(i) .eq. "templvl0") then
@@ -324,7 +344,7 @@ do i = 0, nvars-1
   end if
 
   if (all(A.eq.-999.)) then
-    print (vars(i)+" not present in case1 input file.")
+    print ("'"+vars(i)+"' not present in case1 input file.")
     delete(A)
     continue       ; procede to next variable in do loop
   end if
@@ -538,7 +558,9 @@ do i = 0, nvars-1
       B@units = "g/kg"      
     end if
 
-    if (vars(i).eq."mld" .or. vars(i).eq."mlts") then
+    if (vars(i).eq."mld" .or. vars(i).eq."bld" \
+    .or. vars(i) .eq. "mlts" .or. vars(i) .eq. "mldl82" \
+    .or. vars(i) .eq. "mldb04" ) then
       delete(B)    
       B = inptr2->mld(0,:,:)
       B@long_name = "Mixed layer depth"
@@ -561,9 +583,24 @@ do i = 0, nvars-1
  ;-------------
 
   else                               ; CASE 2 IS MODEL
+    if (vars(i) .eq. "mld") then
+      B = get_mld (inptr2)
+    end if
+
+    if (vars(i) .eq. "bld") then
+      B = get_bld (inptr2)
+    end if
 
     if (vars(i) .eq. "mlts") then
       B = get_mlts (inptr2)
+    end if
+
+    if (vars(i) .eq. "mldl82") then
+      B = get_mldl82 (inptr2)
+    end if
+
+    if (vars(i) .eq. "mldb04") then
+      B = get_mldb04 (inptr2)
     end if
 
     if (vars(i) .eq. "templvl0") then

--- a/packages/BLOM_DIAG/code/plot_latlon_monthly.ncl
+++ b/packages/BLOM_DIAG/code/plot_latlon_monthly.ncl
@@ -3,7 +3,7 @@
 ; Mark Stevens Sept 2001
 ; Rich Neale Jan 2008
 ; Johan Liakka Dec 2017
-; Yanchun He Jul 2019: Update for monthly mlts
+; Yanchun He Jul 2019: Update for monthly mixed layer depth by de Boyer Montegut 2004
 ;********************************************************
 load "$DIAG_CODE/functions_latlon.ncl"
 ;********************************************************
@@ -124,16 +124,16 @@ end if
 ; define variables to plot
 ;************************************************
 ; contours definition (global)
-cntrs_mlts=(/10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175, 200, 250, 300, 400, 500, 750/)
-dcntrs_mlts=(/-250,-200,-150,-100,-75,-50,-25,-10,-5,5,10,25,50,75,100,150,200,250/)
+cntrs_mld=(/10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175, 200, 250, 300, 400, 500, 750/)
+dcntrs_mld=(/-250,-200,-150,-100,-75,-50,-25,-10,-5,5,10,25,50,75,100,150,200,250/)
 
 ; model variables
-vars = (/"mlts"/)
+vars = (/"mldb04"/)
 
 ; define contour intervals
-cntrs = (/cntrs_mlts/)
+cntrs = (/cntrs_mld/)
 
-dcntrs = (/dcntrs_mlts/)
+dcntrs = (/dcntrs_mld/)
 
 nvars = dimsizes(vars)
 
@@ -196,9 +196,8 @@ do i = 0, nvars-1
 ;----------------------------
 ; Test case: CASE 1 MODEL
 ;----------------------------
-
-  if (vars(i) .eq. "mlts") then
-    A = get_mlts (inptr1)
+  if (vars(i) .eq. "mldb04") then
+    A = get_mldb04 (inptr1)
   end if
 
   if (all(A.eq.-999.)) then
@@ -233,7 +232,7 @@ do i = 0, nvars-1
 ; get the variable
 
     B = -999.
-    if (vars(i).eq."mlts") then
+    if (vars(i).eq."mldb04") then
       delete(B)    
       B = inptr2->mld(0,:,:)
       B@long_name = "Mixed layer depth"
@@ -250,8 +249,8 @@ do i = 0, nvars-1
 
   else                               ; CASE 2 IS MODEL
 
-    if (vars(i) .eq. "mlts") then
-      B = get_mlts (inptr2)
+    if (vars(i) .eq. "mldb04") then
+      B = get_mldb04 (inptr2)
     end if
 
     if (all(B.eq.-999.)) then
@@ -381,6 +380,8 @@ do i = 0, nvars-1
     else  
       res@tiMainString = case2
     end if
+    res@gsnLeftString = B@long_name
+    res@gsnRightString = B@units
     res@gsnCenterString = "mean = "+sprintf("%6.2f",gblmean_B)
     res@lbTitleString = "Min = "+sprintf("%6.2f",min2)+ \
                         " Max = "+sprintf("%6.2f",max2)

--- a/packages/BLOM_DIAG/code/plot_mld_annual.ncl
+++ b/packages/BLOM_DIAG/code/plot_mld_annual.ncl
@@ -28,7 +28,7 @@ rgb_filed = rgb_dir+"/bluered2.rgb"
 inptr1   = addfile(infile1,"r")
 lat1     = inptr1->lat
 lon1     = inptr1->lon
-A        = inptr1->mld(0,:,:)
+A        = inptr1->mldb04(0,:,:)
 nlat1    = dimsizes(lat1)
 nlon1    = dimsizes(lon1)
 yrs_ave1 = fyr1+"-"+lyr1
@@ -56,7 +56,7 @@ else
   inptr2   = addfile(infile2,"r")
   lat2     = inptr2->lat
   lon2     = inptr2->lon
-  B        = inptr2->mld(0,:,:)
+  B        = inptr2->mldb04(0,:,:)
   nlat2    = dimsizes(lat2)
   nlon2    = dimsizes(lon2)
   yrs_ave2 = fyr2+"-"+lyr2

--- a/packages/BLOM_DIAG/code/plot_mld_monthly.ncl
+++ b/packages/BLOM_DIAG/code/plot_mld_monthly.ncl
@@ -57,7 +57,7 @@ if (cmonth.eq."12") then
   smonth="Dec"
 end if
 
-print("Computing mld from density profiles ("+smonth+")...")
+print("Computing mldb04 from density profiles ("+smonth+")...")
 
 ; CASE 1 Model
 inptr1 = addfile(infile1,"r")
@@ -144,16 +144,16 @@ end if
 ; define variables to plot
 ;************************************************
 ; contours definition (global)
-cntrs_mld=(/10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175, 200, 250, 300, 400, 500, 750/)
-dcntrs_mld=(/-250,-200,-150,-100,-75,-50,-25,-10,-5,5,10,25,50,75,100,150,200,250/)
+cntrs_mldb04=(/10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175, 200, 250, 300, 400, 500, 750/)
+dcntrs_mldb04=(/-250,-200,-150,-100,-75,-50,-25,-10,-5,5,10,25,50,75,100,150,200,250/)
 
 ; model variables
-vars = (/"mld"/)
+vars = (/"mldb04"/)
 
 ; define contour intervals
-cntrs = (/cntrs_mld/)
+cntrs = (/cntrs_mldb04/)
 
-dcntrs = (/dcntrs_mld/)
+dcntrs = (/dcntrs_mldb04/)
 
 nvars = dimsizes(vars)
 
@@ -217,8 +217,8 @@ do i = 0, nvars-1
 ; Test case: CASE 1 MODEL
 ;----------------------------
 
-  if (vars(i) .eq. "mld") then
-    A = get_mld (inptr1)
+  if (vars(i) .eq. "mldb04") then
+    A = cal_mldb04 (inptr1)
   end if
 
   if (all(A.eq.-999.)) then
@@ -253,7 +253,7 @@ do i = 0, nvars-1
 ; get the variable
 
     B = -999.
-    if (vars(i).eq."mld") then
+    if (vars(i).eq."mldb04") then
       delete(B)    
       B = inptr2->mld(0,:,:)
       B@long_name = "Mixed layer depth"
@@ -270,8 +270,8 @@ do i = 0, nvars-1
 
   else                               ; CASE 2 IS MODEL
 
-    if (vars(i) .eq. "mld") then
-      B = get_mld (inptr2)
+    if (vars(i) .eq. "mldb04") then
+      B = cal_mldb04 (inptr2)
     end if
 
     if (all(B.eq.-999.)) then
@@ -368,8 +368,8 @@ do i = 0, nvars-1
   filevardef(fout, "time" ,typeof(time1),getvardims(time1))
   filevardef(fout, "lat"  ,typeof(lat1),getvardims(lat1))
   filevardef(fout, "lon"  ,typeof(lon1),getvardims(lon1))
-  filevardef(fout, "mld"  ,typeof(Anew)  ,getvardims(Anew))
-  filevarattdef(fout,"mld",Anew)
+  filevardef(fout, "mldb04"  ,typeof(Anew)  ,getvardims(Anew))
+  filevarattdef(fout,"mldb04",Anew)
   filevarattdef(fout,"time" ,time1)
   filevarattdef(fout,"lat"  ,lat1)
   filevarattdef(fout,"lon"  ,lon1)
@@ -377,7 +377,7 @@ do i = 0, nvars-1
   fout->time   = (/time1/)
   fout->lat    = (/lat1/)
   fout->lon    = (/lon1/)
-  fout->mld    = (/Anew/)
+  fout->mldb04 = (/Anew/)
 
   if (compare.eq."USER") then
     Bnew = new((/1,nlat2,nlon2/),float)
@@ -395,8 +395,8 @@ do i = 0, nvars-1
     filevardef(fout, "time" ,typeof(time2),getvardims(time2))
     filevardef(fout, "lat"  ,typeof(lat2),getvardims(lat2))
     filevardef(fout, "lon"  ,typeof(lon2),getvardims(lon2))
-    filevardef(fout, "mld"  ,typeof(Bnew)  ,getvardims(Bnew))
-    filevarattdef(fout,"mld",Bnew)
+    filevardef(fout, "mldb04"  ,typeof(Bnew)  ,getvardims(Bnew))
+    filevarattdef(fout,"mldb04",Bnew)
     filevarattdef(fout,"time" ,time2)
     filevarattdef(fout,"lat"  ,lat2)
     filevarattdef(fout,"lon"  ,lon2)
@@ -404,7 +404,7 @@ do i = 0, nvars-1
     fout->time   = (/time2/)
     fout->lat    = (/lat2/)
     fout->lon    = (/lon2/)
-    fout->mld    = (/Bnew/)
+    fout->mldb04    = (/Bnew/)
   end if
 
 ;--------------------- Open files for plots ------------------------------

--- a/packages/BLOM_DIAG/code/webpage_rmorphan.sh
+++ b/packages/BLOM_DIAG/code/webpage_rmorphan.sh
@@ -8,6 +8,6 @@ for fname in $(grep -o 'set[^"><]*.png' $1 |uniq); do
         ln=$(echo $text |cut -d: -f1)
         #alt=$(echo $text |grep -o 'alt="[[:alnum:]. -]*"' |cut -d'"' -f2)
         #sed -i "${ln}s/.*/    \<TD\>$alt/" $1
-        sed -i "${ln}s/.*/    \<TD\>missing/" $1
+        sed -i "${ln}s+.*+    \<TD\>N/A+" $1
     fi
 done

--- a/packages/BLOM_DIAG/html/webpage3.html
+++ b/packages/BLOM_DIAG/html/webpage3.html
@@ -1,8 +1,17 @@
 <h3 id="2D-fields-annual-means">2D fields - annual means
 <TABLE width='100%'>
 <TR>
-    <TH style="vertical-align:middle"> Sea surface height
+    <TH rowspan="2" style="vertical-align:middle"> Surface climatologies
+    <TH> Sea surface height
+    <TH> Mixed Layer Depth (mld/bld) <br> (by TKE)
+    <TH> Mixed Layer Depth (mlts/mldl82) <br> (by Levitus 1982)
+    <TH> Mixed Layer Ddepth (mldb04) <br> (by de Boyer Montegut 2004)
+</TR>
+<TR>
     <TD><a target="_self" href='set3/set3_ann_sealv_CINFO.png'><img src="set3/set3_ann_sealv_CINFO.png" alt="0m"></a>
+    <TD><a target="_self" href='set3/set3_ann_mld_CINFO.png'><img src="set3/set3_ann_mld_CINFO.png" alt="0m"></a>
+    <TD><a target="_self" href='set3/set3_ann_mlts_CINFO.png'><img src="set3/set3_ann_mlts_CINFO.png" alt="0m"></a>
+    <TD><a target="_self" href='set3/set3_ann_mldb04_CINFO.png'><img src="set3/set3_ann_mldb04_CINFO.png" alt="0m"></a>
 </TR>
 <TR>
     <TH rowspan="2" style="vertical-align:middle">Temperature
@@ -63,7 +72,7 @@
 <h3 id="2D-fields-seasonal-monthly-means">Horizontal fields - seasonal/monthly means</h3>
 <TABLE width='100%'>
 <TR>
-    <TH rowspan="4" style="vertical-align:middle"> MLD <br> (TS-derived)
+  <TH rowspan="4" style="vertical-align:middle"> Mixed Layer Depth <br> (mldb04)
     <TH> Jan
     <TH> Feb
     <TH> Mar
@@ -72,12 +81,12 @@
     <TH> Jun
 </TR>
 <TR>
-    <TD><a target="_self" href='set3/set3_01_mld_CINFO.png'><img src="set3/set3_01_mld_CINFO.png" alt="Jan" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_02_mld_CINFO.png'><img src="set3/set3_02_mld_CINFO.png" alt="Feb" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_03_mld_CINFO.png'><img src="set3/set3_03_mld_CINFO.png" alt="Mar" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_04_mld_CINFO.png'><img src="set3/set3_04_mld_CINFO.png" alt="Apr" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_05_mld_CINFO.png'><img src="set3/set3_05_mld_CINFO.png" alt="May" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_06_mld_CINFO.png'><img src="set3/set3_06_mld_CINFO.png" alt="Jun" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_01_mldb04_CINFO.png'><img src="set3/set3_01_mldb04_CINFO.png" alt="Jan" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_02_mldb04_CINFO.png'><img src="set3/set3_02_mldb04_CINFO.png" alt="Feb" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_03_mldb04_CINFO.png'><img src="set3/set3_03_mldb04_CINFO.png" alt="Mar" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_04_mldb04_CINFO.png'><img src="set3/set3_04_mldb04_CINFO.png" alt="Apr" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_05_mldb04_CINFO.png'><img src="set3/set3_05_mldb04_CINFO.png" alt="May" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_06_mldb04_CINFO.png'><img src="set3/set3_06_mldb04_CINFO.png" alt="Jun" class="img_2Dseas"></a>
 </TR>
 <TR>
     <TH> Jul
@@ -89,13 +98,13 @@
     <TH> Ann
 </TR>
 <TR>
-    <TD><a target="_self" href='set3/set3_07_mld_CINFO.png'><img src="set3/set3_07_mld_CINFO.png" alt="Jul" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_08_mld_CINFO.png'><img src="set3/set3_08_mld_CINFO.png" alt="Aug" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_09_mld_CINFO.png'><img src="set3/set3_09_mld_CINFO.png" alt="Sep" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_10_mld_CINFO.png'><img src="set3/set3_10_mld_CINFO.png" alt="Oct" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_11_mld_CINFO.png'><img src="set3/set3_11_mld_CINFO.png" alt="Nov" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_12_mld_CINFO.png'><img src="set3/set3_12_mld_CINFO.png" alt="Dec" class="img_2Dseas"></a>
-    <TD><a target="_self" href='set3/set3_ann_mld_CINFO.png'><img src="set3/set3_ann_mld_CINFO.png" alt="Ann" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_07_mldb04_CINFO.png'><img src="set3/set3_07_mldb04_CINFO.png" alt="Jul" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_08_mldb04_CINFO.png'><img src="set3/set3_08_mldb04_CINFO.png" alt="Aug" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_09_mldb04_CINFO.png'><img src="set3/set3_09_mldb04_CINFO.png" alt="Sep" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_10_mldb04_CINFO.png'><img src="set3/set3_10_mldb04_CINFO.png" alt="Oct" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_11_mldb04_CINFO.png'><img src="set3/set3_11_mldb04_CINFO.png" alt="Nov" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_12_mldb04_CINFO.png'><img src="set3/set3_12_mldb04_CINFO.png" alt="Dec" class="img_2Dseas"></a>
+    <TD><a target="_self" href='set3/set3_ann_mldb04_CINFO.png'><img src="set3/set3_ann_mldb04_CINFO.png" alt="Ann" class="img_2Dseas"></a>
 </TR>
 </TABLE>
 <TABLE width='100%'>


### PR DESCRIPTION
According to the updates of BLOM in https://github.com/NorESMhub/BLOM/pull/712, and related issue in https://github.com/NorESMhub/NorESM-Diagnostics/issues/9, there are updates on the estimated model mixed layer depth:
1. use and show in the webpage either `mld` or `bld` for mixed layer depth defined by the TKE
2. use and show in the webpage either `mlts` or `mldl82` for mixed layer depth defined by the critical bouyancy criterion (described by Griffes et al., 2016 according to Levitus 1982), refered to ocean (model) surface;
3. use and show in the webpage either `mldb04` for mixed layer depth defined by the density criterion, as by de Boyer Montegut 2004; referred to top 10 m.

However, all these estimated model simulated mixed-layer depths are compared with the `de Boyer Montegut 2004` observation-based datasets. 

The simulated seasonal (monthly) mixed layer depths shown on the webpage are estimated using the same density criterion as `de Boyer Montegut 2004`.

An example of the new mixed-layer depth diagnostics is available here for: [NOIIAJRARYF8485OC_TL319_tn14_CMIP7_diag_20260204](https://ns9560k.web.sigma2.no/datalake/diagnostics/noresm/yanchun/NOIIAJRARYF8485OC_TL319_tn14_CMIP7_diag_20260204/BLOM_DIAG/yrs51to52-obs/index.html#2D-fields-seasonal-monthly-means)

@matsbn Could you please have a look if this looks OK?

(note that the other changes as indicated in https://github.com/NorESMhub/BLOM/pull/712 have not been updated yet)